### PR TITLE
removed hard-coded start year and changed default end year

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: demographydash
 Title: A Shiny Dashboard for Demographic Analysis
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Authors@R:
     person("Jorge", "Cimentada", , "cimentadaj@gmail.com", role = c("aut", "cre"))
 Description: This dashboard aims to make demographic analysis avialable to
@@ -15,7 +15,7 @@ Imports:
     ggplot2,
     golem (>= 0.4.1),
     magrittr,
-    OPPPserver (>= 0.0.6),
+    OPPPserver (>= 0.0.6.9004),
     plotly,
     rlang,
     scales,

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -345,11 +345,10 @@ handle_navigation <- function(reactive_pop, reactive_tfr, input, output) {
 #' @importFrom shinyjs hide show
 #' @noRd
 begin_simulation <- function(input, pop_dt, simulation_results, output) {
-  # TODO: fix 2021
   forecast_res <- reactive({
     run_forecast(
       country = input$wpp_country,
-      start_year = 2021,
+      start_year = as.numeric(input$wpp_starting_year),
       end_year = as.numeric(input$wpp_ending_year),
       output_dir = "/tmp/hasdaney213/",
       pop = pop_dt()

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -15,7 +15,7 @@ input_page <- function() {
     div(
       class = "two fields",
       create_field_set("calendar", "Starting Year", "wpp_starting_year", 2023:2099, 2023),
-      create_field_set("calendar", "Ending Year", "wpp_ending_year", 2024:2100, 2024)
+      create_field_set("calendar", "Ending Year", "wpp_ending_year", 2024:2100, 2100)
     )
   )
 }


### PR DESCRIPTION
The start year was still hard-coded to 2021, so this now allows to run the simulation from any start year. It requires a bayesPop version 10.0-1.9006 which is on GitHub. I also changed the default end year to agree with the scoping document. 